### PR TITLE
Add security policies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "sidekiq"
 gem "statsd-instrument"
 gem "sinatra", require: false
 gem "omniauth-google-oauth2"
+gem "pundit"
 
 gem "sprockets", ">=3.4.0"
 gem "sprockets-es6", require: "sprockets/es6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
       byebug (~> 8.0)
       pry (~> 0.10)
     puma (2.15.3)
+    pundit (1.0.1)
+      activesupport (>= 3.0.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -246,6 +248,7 @@ DEPENDENCIES
   pg
   pry-byebug
   puma
+  pundit
   rails (= 4.2.4)
   responders
   rubocop

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include Pundit
   include Authenticated
 
   protect_from_forgery with: :exception

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,9 +1,12 @@
 class DocumentsController < ApplicationController
   def show
+    @document = Document.find(document_id)
+    authorize(@document)
   end
 
   def download
     @document = Document.find(document_id)
+    authorize(@document)
 
     if @document.file.extension == extension
       send_file @document.file_ptr.current_path,

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,7 +2,6 @@ class Document < ActiveRecord::Base
   mount_uploader :file_ptr, FileUploader
 
   belongs_to :documentable, polymorphic: true
-  has_one :user, through: :documentable
 
   validates :file_ptr, presence: true
 
@@ -12,6 +11,7 @@ class Document < ActiveRecord::Base
   }
 
   delegate :file, to: :file_ptr
+  delegate :user, to: :documentable
 
   def content
     @content ||= File.open(file_ptr.current_path, "r").read

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    scope.where(id: record.id).exists?
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  def scope
+    Pundit.policy_scope!(user, record.class)
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -1,0 +1,22 @@
+class DocumentPolicy < ApplicationPolicy
+  def show?
+    owner? || handover_creator?
+  end
+
+  def download?
+    owner? || handover_creator?
+  end
+
+  private
+
+  def owner?
+    record.documentable.user == user
+  end
+
+  def handover_creator?
+    return true unless record.documentable.is_a?(Submission)
+
+    submission = record.documentable
+    submission.handover.user == user
+  end
+end

--- a/test/controllers/authentications_controller_test.rb
+++ b/test/controllers/authentications_controller_test.rb
@@ -16,7 +16,7 @@ class AuthenticationsControllerTest < ActionController::TestCase
     mock_auth_request_for(
       :google,
       user: User.new(
-        uid: "654321",
+        uid: "754321",
         name: "Roger Lemieux",
         email: "lemieux.roger@gmail.com",
       ),

--- a/test/controllers/documents_controller_test.rb
+++ b/test/controllers/documents_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class DocumentsControllerTest < ActionController::TestCase
   setup do
     @document = documents(:platypus)
+    sign_in(users(:henry))
   end
 
   test "#download" do
@@ -23,5 +24,37 @@ class DocumentsControllerTest < ActionController::TestCase
     get :show, id: @document.id
 
     assert_response :ok
+  end
+
+  test "#download is not authorized when signed out" do
+    sign_out
+
+    assert_raises(Pundit::NotAuthorizedError) do
+      get :download, id: @document.id, extension: @document.file.extension
+    end
+  end
+
+  test "#show is not authorized when signed out" do
+    sign_out
+
+    assert_raises(Pundit::NotAuthorizedError) do
+      get :show, id: @document.id
+    end
+  end
+
+  test "#download is not authorized when you are not the owner not the creator of the handover" do
+    sign_in(users(:marcel))
+
+    assert_raises(Pundit::NotAuthorizedError) do
+      get :download, id: @document.id, extension: @document.file.extension
+    end
+  end
+
+  test "#show is not authorized when you are not the owner not the creator of the handover" do
+    sign_in(users(:marcel))
+
+    assert_raises(Pundit::NotAuthorizedError) do
+      get :show, id: @document.id
+    end
   end
 end

--- a/test/fixtures/documents.yml
+++ b/test/fixtures/documents.yml
@@ -3,11 +3,11 @@ bragging:
   file_ptr: <%= upload(Document, :file_ptr, "text_document1.txt") %>
 
 fraudulent_bragging:
-  documentable: log240_lab1 (Submission)
+  documentable: log121_lab1 (Submission)
   file_ptr: <%= upload(Document, :file_ptr, "text_document2.txt") %>
 
 empty:
-  documentable: log240_lab1 (Submission)
+  documentable: log121_lab1 (Submission)
   file_ptr: <%= upload(Document, :file_ptr, "empty.txt") %>
 
 platypus:
@@ -15,15 +15,15 @@ platypus:
   file_ptr: <%= upload(Document, :file_ptr, "platypus1.txt") %>
 
 fraudulent_platypus:
-  documentable: log240_lab1 (Submission)
+  documentable: log121_lab1 (Submission)
   file_ptr: <%= upload(Document, :file_ptr, "platypus2.txt") %>
 
 platypus_image:
-  documentable: log240_lab1 (Submission)
+  documentable: log121_lab1 (Submission)
   file_ptr: <%= upload(Document, :file_ptr, "platypus.jpg") %>
 
 platypus_with_no_extension:
-  documentable: log240_lab1 (Submission)
+  documentable: log121_lab1 (Submission)
   file_ptr: <%= upload(Document, :file_ptr, "platypus") %>
 
 makefile_boilerplate:

--- a/test/fixtures/submissions.yml
+++ b/test/fixtures/submissions.yml
@@ -1,7 +1,7 @@
 log121_lab1:
   handover: log121_lab1
-  user_id: henry
+  user: henry
 
 log240_lab1:
   handover: log240_lab1
-  user_id: henry
+  user: henry

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -6,6 +6,12 @@ gaston:
 
 henry:
   name: "Henry Lemieux"
-  email: "henry.lemieux@gmail.com"
+  email: "lemieux.henry@gmail.com"
   provider: "google"
-  uid: "54321"
+  uid: "654321"
+
+marcel:
+  name: "Marcel Gratton"
+  email: "gratton.marcel@gmail.com"
+  provider: "google"
+  uid: "555555"

--- a/test/support/session_helper.rb
+++ b/test/support/session_helper.rb
@@ -1,0 +1,18 @@
+module Remets
+  module SessionHelper
+    def sign_in(user)
+      @controller.current_user = user
+      return unless block_given?
+
+      begin
+        yield
+      ensure
+        sign_out
+      end
+    end
+
+    def sign_out
+      @controller.current_user = nil
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,3 +21,7 @@ class ActiveSupport::TestCase
   include ActionDispatch::TestProcess
   include ActiveJob::TestHelper
 end
+
+class ActionController::TestCase
+  include Remets::SessionHelper
+end

--- a/test/units/policies/application_policy_test.rb
+++ b/test/units/policies/application_policy_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class ApplicationPolicyTest < ActiveSupport::TestCase
+end

--- a/test/units/policies/document_policy_test.rb
+++ b/test/units/policies/document_policy_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class DocumentPolicyTest < ActiveSupport::TestCase
+end


### PR DESCRIPTION
This PR add policies using https://github.com/elabs/pundit. This example provides the following permissions to a document resource. The user has access when : 
- He's the owner of the submission.
- He's the owner of the handover.

@xdrdak what do you think?
