### PR TITLE
Add match model

### DIFF
--- a/app/models/document_match.rb
+++ b/app/models/document_match.rb
@@ -3,6 +3,8 @@ class DocumentMatch < ActiveRecord::Base
   belongs_to :compared_document, class_name: Document
   belongs_to :match, inverse_of: :document_matches
 
+  delegate :fingerprints, to: :match
+
   validates(
     :reference_document_id,
     :compared_document_id,

--- a/app/models/document_match.rb
+++ b/app/models/document_match.rb
@@ -1,7 +1,7 @@
 class DocumentMatch < ActiveRecord::Base
   belongs_to :reference_document, class_name: Document
   belongs_to :compared_document, class_name: Document
-  belongs_to :match
+  belongs_to :match, inverse_of: :document_matches
 
   validates(
     :reference_document_id,

--- a/app/models/document_match.rb
+++ b/app/models/document_match.rb
@@ -1,25 +1,36 @@
 class DocumentMatch < ActiveRecord::Base
   belongs_to :reference_document, class_name: Document
   belongs_to :compared_document, class_name: Document
+  belongs_to :match
 
-  validates :reference_document_id,
+  validates(
+    :reference_document_id,
     :compared_document_id,
-    :fingerprints,
-    presence: true
+    :match,
+    presence: true,
+  )
 
   scope :relevant_matches, lambda { |document|
-    where(reference_document_id: document.id)
+    joins(:match)
+      .where(reference_document_id: document.id)
       .order("array_length(fingerprints, 1) DESC")
   }
 
   def self.create_from!(reference, compared)
-    matching_fingerprints = reference.fingerprints & compared.fingerprints
-    return unless matching_fingerprints.present?
+    fingerprints = reference.fingerprints & compared.fingerprints
+    return unless fingerprints.present?
+
+    match = Match.create!(fingerprints: fingerprints)
 
     create!(
       reference_document: reference,
       compared_document: compared,
-      fingerprints: matching_fingerprints,
+      match: match,
+    )
+    create!(
+      reference_document: compared,
+      compared_document: reference,
+      match: match,
     )
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,0 +1,4 @@
+class Match < ActiveRecord::Base
+  has_many :document_matches
+  validates :fingerprints, presence: true
+end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,4 +1,4 @@
 class Match < ActiveRecord::Base
-  has_many :document_matches
+  has_many :document_matches, inverse_of: :match
   validates :fingerprints, presence: true
 end

--- a/db/migrate/20150926225705_create_document_match.rb
+++ b/db/migrate/20150926225705_create_document_match.rb
@@ -3,7 +3,7 @@ class CreateDocumentMatch < ActiveRecord::Migration
     create_table :document_matches do |t|
       t.integer :reference_document_id
       t.integer :compared_document_id
-      t.integer :fingerprints, array: true, default: []
+      t.integer :match_id
       t.timestamps
     end
   end

--- a/db/migrate/20160103173113_create_match.rb
+++ b/db/migrate/20160103173113_create_match.rb
@@ -1,0 +1,7 @@
+class CreateMatch < ActiveRecord::Migration
+  def change
+    create_table :matches do |t|
+      t.integer :fingerprints, array: true, default: []
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150926225705) do
+ActiveRecord::Schema.define(version: 20160103173113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 20150926225705) do
   create_table "document_matches", force: :cascade do |t|
     t.integer  "reference_document_id"
     t.integer  "compared_document_id"
-    t.integer  "fingerprints",          default: [], array: true
+    t.integer  "match_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -43,6 +43,10 @@ ActiveRecord::Schema.define(version: 20150926225705) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "matches", force: :cascade do |t|
+    t.integer "fingerprints", default: [], array: true
   end
 
   create_table "submissions", force: :cascade do |t|

--- a/test/units/jobs/document_indexing_job_test.rb
+++ b/test/units/jobs/document_indexing_job_test.rb
@@ -5,9 +5,16 @@ class DocumentIndexingJobTest < ActiveSupport::TestCase
 
   self.use_transactional_fixtures = true
 
+  test "#perform add document matches for (n - 1) * 2 documents fingerprinted" do
+    Document.update_all(fingerprints: [1234])
+    assert_difference("DocumentMatch.count", (Document.count - 1) * 2) do
+      DocumentIndexingJob.perform_now(documents(:platypus).id)
+    end
+  end
+
   test "#perform add matches for n-1 documents fingerprinted" do
     Document.update_all(fingerprints: [1234])
-    assert_difference("DocumentMatch.count", Document.count - 1) do
+    assert_difference("Match.count", Document.count - 1) do
       DocumentIndexingJob.perform_now(documents(:platypus).id)
     end
   end
@@ -19,18 +26,26 @@ class DocumentIndexingJobTest < ActiveSupport::TestCase
   end
 
   test "#perform add a match with the intersection of fingerprints" do
-    Document.destroy_all
+    [Document, DocumentMatch, Match].each(&:destroy_all)
+
     reference = Document.create!(file_ptr: empty_file_upload, windows: [[0, 1234], [1, 9876], [4, 5678]])
     compared = Document.create!(file_ptr: empty_file_upload, windows: [[0, 1234], [1, 3456], [4, 6666]])
 
-    assert_difference("DocumentMatch.count", 1) do
-      DocumentIndexingJob.perform_now(reference.id)
+    assert_difference("DocumentMatch.count", 2) do
+      assert_difference("Match.count") do
+        DocumentIndexingJob.perform_now(reference.id)
+      end
     end
-    match = DocumentMatch.last
+    match1 = DocumentMatch.first
+    match2 = DocumentMatch.second
 
-    assert_equal [1234], match.fingerprints
-    assert_equal reference, match.reference_document
-    assert_equal compared, match.compared_document
+    assert_equal [1234], match1.fingerprints
+    assert_equal reference, match1.reference_document
+    assert_equal compared, match1.compared_document
+
+    assert_equal [1234], match2.fingerprints
+    assert_equal compared, match2.reference_document
+    assert_equal reference, match2.compared_document
   end
 
   test "#perform does not add a match when the intersection is empty" do

--- a/test/units/models/document_match_test.rb
+++ b/test/units/models/document_match_test.rb
@@ -10,7 +10,7 @@ class DocumentMatchTest < ActiveSupport::TestCase
     document1.windows = [[0, 1234], [1, 5678]]
     document2.windows = [[0, 4321], [1, 8765]]
 
-    assert_no_difference("DocumentMatch.count") do
+    assert_no_difference("DocumentMatch.count", "Match.count") do
       DocumentMatch.create_from!(document1, document2)
     end
   end
@@ -22,29 +22,38 @@ class DocumentMatchTest < ActiveSupport::TestCase
     document1.windows = [[0, 1234], [1, 5678]]
     document2.windows = [[9, 1234], [1, 8765]]
 
-    assert_difference("DocumentMatch.count") do
-      DocumentMatch.create_from!(document1, document2)
+    assert_difference("DocumentMatch.count", 2) do
+      assert_difference("Match.count") do
+        DocumentMatch.create_from!(document1, document2)
+      end
     end
   end
 
   test "#relevant_matches return the matches for the compared document" do
     reference = documents(:platypus)
     DocumentMatch.destroy_all
-    DocumentMatch.create(
+    Match.destroy_all
+
+    match1 = Match.create!(fingerprints: [1234, 5678, 0000])
+    match2 = Match.create!(fingerprints: [1234, 5678])
+
+    DocumentMatch.create!(
       reference_document: reference,
       compared_document: documents(:fraudulent_platypus),
-      fingerprints: [1234, 5678, 0000],
+      match: match1,
     )
-    DocumentMatch.create(
+    DocumentMatch.create!(
       reference_document: reference,
       compared_document: documents(:fraudulent_bragging),
-      fingerprints: [1234, 5678],
-    )
-    DocumentMatch.create(
-      reference_document: reference,
-      compared_document: documents(:empty),
+      match: match2,
     )
 
-    assert_equal 2, DocumentMatch.relevant_matches(reference).size
+    relevant_matches = DocumentMatch.relevant_matches(reference)
+    assert_equal 2, relevant_matches.size
+    assert_equal documents(:fraudulent_platypus).id,
+      relevant_matches.first.compared_document_id
+    assert_equal documents(:fraudulent_bragging).id,
+      relevant_matches.second.compared_document_id
+    assert relevant_matches.all? { |m| m.reference_document_id == reference.id }
   end
 end

--- a/test/units/models/match_test.rb
+++ b/test/units/models/match_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class MatchTest < ActiveSupport::TestCase
+end


### PR DESCRIPTION
@xdrdak I've updated the match model to do the following:

```
# Public: Creates document matches for all the documents previously stored. Only fingerprinted documents
# are considered.
#
# document_id - The id of the document to append to the index
#
# Examples
#
#  # Upload document 1 => No match
#  perform(1) # => nil
#
#  # Upload document 2 => 2 matches
#  perform(2) # => nil
#  # reference_id | compared_id | match_id
#  # -------------+-------------+----------
#  #            1 |           2 |        1
#  #            2 |           1 |        1
#
#  # Upload document 3 => 6 matches
#  perform(3) # => nil
#  # reference_id | compared_id | match_id
#  # -------------+-------------+----------
#  #            1 |           2 |        1
#  #            2 |           1 |        1
#  #            3 |           1 |        2
#  #            3 |           2 |        2
#  #            1 |           3 |        2
#  #            2 |           3 |        2
```

This will reduce duplication of the matching fingerprints since when when we index the documents we need 2 records per comparaison, otherwise it makes it very difficult to query efficiently for the matching results. 

I suppose we can review this later, as I have no idea on how to make this better ATM. 
